### PR TITLE
Remove pkgcache.bin and srcpkgcache.bin

### DIFF
--- a/live-build/ubuntu-touch/hooks/99-remove-lists.binary
+++ b/live-build/ubuntu-touch/hooks/99-remove-lists.binary
@@ -7,5 +7,5 @@
 
 echo "Removing /var/lib/apt/lists/* from the binary"
 find binary/boot/filesystem.dir/var/lib/apt/lists/ -type f | xargs rm -f
-echo "Removing /var/cache/apt/*pkgcache.bin from the binary"
-rm -f binary/boot/filesystem.dir/var/cache/apt/*pkgcache.bin
+echo "Removing apt caches from the binary"
+find binary/boot/filesystem.dir/var/cache/apt/ -type f | xargs rm -f

--- a/live-build/ubuntu-touch/hooks/99-remove-lists.binary
+++ b/live-build/ubuntu-touch/hooks/99-remove-lists.binary
@@ -7,4 +7,5 @@
 
 echo "Removing /var/lib/apt/lists/* from the binary"
 find binary/boot/filesystem.dir/var/lib/apt/lists/ -type f | xargs rm -f
-rm -f binary/boot/filesystem.dir/var/cache/apt/pkgcache.bin binary/boot/filesystem.dir/var/cache/apt/srcpkgcache.bin
+echo "Removing /var/cache/apt/*pkgcache.bin from the binary"
+rm -f binary/boot/filesystem.dir/var/cache/apt/*pkgcache.bin

--- a/live-build/ubuntu-touch/hooks/99-remove-lists.binary
+++ b/live-build/ubuntu-touch/hooks/99-remove-lists.binary
@@ -7,3 +7,4 @@
 
 echo "Removing /var/lib/apt/lists/* from the binary"
 find binary/boot/filesystem.dir/var/lib/apt/lists/ -type f | xargs rm -f
+rm -f binary/boot/filesystem.dir/var/cache/apt/pkgcache.bin binary/boot/filesystem.dir/var/cache/apt/srcpkgcache.bin


### PR DESCRIPTION
It's not possible to run 'apt clean' in the live-build process since apt might run again before it's time for results. Do the same thing that 'apt clean' would do.