### PR TITLE
04-android: Don't setup /odm symlink while building the rootfs

### DIFF
--- a/live-build/ubuntu-touch/hooks/04-android.chroot
+++ b/live-build/ubuntu-touch/hooks/04-android.chroot
@@ -1,17 +1,12 @@
 #!/bin/sh -x
 
-# Setup missing directories and symlinks as
-# commonly required by the device adaptations.
-
-ln -s /android/odm /odm
-
 # Several issues with the rootfs have come up,
 # the image failed to boot due to little permission
 # mismatches. Unlike hoping these issues stop coming up
 # now and again just apply tweaks to the rootfs.
 
 # Fix permissions for dbus-daemon-launcher-helper
-chown root:messagebus /usr/lib/dbus-1.0/dbus-daemon-launch-helper 
+chown root:messagebus /usr/lib/dbus-1.0/dbus-daemon-launch-helper
 chmod 4754 /usr/lib/dbus-1.0/dbus-daemon-launch-helper
 
 # Avoid system-image-dbus crashing over and over


### PR DESCRIPTION
Let halium-install handle this instead.