### PR TITLE
Add mainline subproject with ubuntu-touch-mainline metapackage

### DIFF
--- a/live-build/auto/config
+++ b/live-build/auto/config
@@ -416,6 +416,9 @@ case $PROJECT in
 		if [ "$SUBPROJECT" = "hybris" ]; then
 			HINTS="$HINTS ubuntu-touch-hybris"
 		fi
+                if [ "$SUBPROJECT" = "mainline" ]; then
+                        HINTS="$HINTS ubuntu-touch-mainline"
+                fi
 		add_package install ubuntu-minimal ubuntu-touch systemd-sysv- $HINTS
 
 		COMPONENTS='main restricted universe'


### PR DESCRIPTION
This is needed for pine/librem devices, as they require different packages then hybris.