### PR TITLE
Fix pinning of UBports packages.

### DIFF
--- a/live-build/ubuntu-touch/archives/ubports.pref.binary
+++ b/live-build/ubuntu-touch/archives/ubports.pref.binary
@@ -1,3 +1,7 @@
 Package: *
-Pin: origin repo.ubports.com
-Pin-Priority: 2000
+Pin: release o=UBports,a=xenial_-_edge
+Pin-Priority: 1000
+
+Package: *
+Pin: release o=UBports,a=xenial
+Pin-Priority: 900

--- a/live-build/ubuntu-touch/archives/ubports.pref.chroot
+++ b/live-build/ubuntu-touch/archives/ubports.pref.chroot
@@ -1,3 +1,7 @@
 Package: *
-Pin: origin repo.ubports.com
-Pin-Priority: 2000
+Pin: release o=UBports,a=xenial_-_edge
+Pin-Priority: 1000
+
+Package: *
+Pin: release o=UBports,a=xenial
+Pin-Priority: 900


### PR DESCRIPTION
To avoid having packages in edge channel overridden by packages in
regular release channels, we need to assign separate pin values.

Fixes #7