### PR TITLE
Use auto-imported clicks from CI

### DIFF
--- a/live-build/ubuntu-touch/hooks/60-install-click.chroot
+++ b/live-build/ubuntu-touch/hooks/60-install-click.chroot
@@ -6,11 +6,8 @@ echo "Setting up click packages"
 
 CLICKARCH=$(dpkg --print-architecture)
 
-click_uri=http://cdimage.ubports.com/clicks
+click_uri=https://ci.ubports.com/job/app-importer/lastSuccessfulBuild/artifact/xenial/
 if [ "$CLICKARCH" = "arm64" ]; then
-    # FIXME: this is temporary. Since right now we can't have arm64 clicks in the store
-    # (before implementing fat-packages), we need to fetch the arm64 click list from a
-    # different place 
     click_list=$click_uri/click_list.arm64
 else
     click_list=$click_uri/click_list


### PR DESCRIPTION
Don't use the cdimage server to import clicks, instead use [the auto-importer](https://github.com/ubports/build-tools/blob/master/click_importer.py)'s [job on Jenkins](https://ci.ubports.com/job/app-importer/) for the freshest clicks with the best status monitoring.